### PR TITLE
Fix ios rendering

### DIFF
--- a/components/ui/resizable.tsx
+++ b/components/ui/resizable.tsx
@@ -11,7 +11,7 @@ const ResizablePanelGroup = ({
 }: React.ComponentProps<typeof ResizablePrimitive.PanelGroup>) => (
     <ResizablePrimitive.PanelGroup
         className={cn(
-            'flex h-full w-full data-[panel-group-direction=vertical]:flex-col',
+            'flex h-screen w-full data-[panel-group-direction=vertical]:flex-col',
             className
         )}
         {...props}

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -2,6 +2,7 @@ import type { Config } from 'tailwindcss'
 import { CourseGroup } from './data/enums'
 
 const config = {
+    important: true,
     darkMode: ['class'],
     content: [
         './pages/**/*.{ts,tsx}',


### PR DESCRIPTION
The bug on iOS was caused by this https://reactflow.dev/learn/troubleshooting#004

The `Resizable.PanelGroup` that ultimately wraps the `ReactFlow` component by default sets height and width to `100%` and that needs to be overwritten hence the `important: true` in tailwind config.

By setting the height of the `PanelGroup` to `100vh` instead of `100%`, iOS Safari renders everything smoothly. Though, on MacOS Safari the problem was not present (thanks Tim Apple).

Not sure if this breaks the layout on other devices. For me it looked good on chromium based browsers as well as Safari.